### PR TITLE
Enhance type hints

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -53,12 +53,12 @@ final class Command
     /**
      * @var string built command
      */
-    private $command;
+    private $command = '';
 
     /**
      * @var string url
      */
-    private $url;
+    private $url = '';
 
     /**
      * @var string command template
@@ -112,9 +112,9 @@ final class Command
 
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getUrl(): ?string
+    public function getUrl(): string
     {
         return $this->url;
     }
@@ -272,7 +272,7 @@ final class Command
      * @param string $search
      * @return string
      */
-    private function getTemplatePartPattern($search): string
+    private function getTemplatePartPattern(string $search): string
     {
         return '/ ?' . preg_quote($search, '/') . ' ?/';
     }
@@ -361,7 +361,7 @@ final class Command
      * @param bool $parse
      * @return Command
      */
-    public function setRequest(?ServerRequestInterface $request, $parse = true): Command
+    public function setRequest(?ServerRequestInterface $request, bool $parse = true): Command
     {
         $this->request = $request;
         if ($parse) {


### PR DESCRIPTION
# Changed log
- Let the `$command` variable be empty string by default.
- Let the `$url` variable be empty string by default.
- The `getUrl` method returns type hint should be `string` and it will not be `null` if the default `$url` value is empty string.
- Add the `string` type hint for `$search` parameter inside `getTemplatePartPattern` method.
- Add the `bool` type hint for `$parse` parameter inside `setRequest` method.