### PR TITLE
Using the assertSame to make assert equals strict

### DIFF
--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -19,21 +19,21 @@ class CommandTest extends TestCase
     public function testBuildMinimal(): void
     {
         $command = new Command();
-        $this->assertEquals('curl', $command->build());
+        $this->assertSame('curl', $command->build());
     }
 
     public function testBuildWithUrl(): void
     {
         $command = new Command();
         $command->setUrl('http://example.com/test');
-        $this->assertEquals('curl http://example.com/test', $command->build());
+        $this->assertSame('curl http://example.com/test', $command->build());
     }
 
     public function testBuildWithOption(): void
     {
         $command = new Command();
         $command->addOption('-v');
-        $this->assertEquals('curl -v', $command->build());
+        $this->assertSame('curl -v', $command->build());
     }
 
     public function testBuildWithOptions(): void
@@ -41,14 +41,14 @@ class CommandTest extends TestCase
         $command = new Command();
         $command->addOption('-v');
         $command->addOption('-L');
-        $this->assertEquals('curl -v -L', $command->build());
+        $this->assertSame('curl -v -L', $command->build());
     }
 
     public function testBuildWithUrlAndOption(): void
     {
         $command = $this->getNewCommand();
         $command->addOption('-v');
-        $this->assertEquals('curl -v http://example.com', $command->build());
+        $this->assertSame('curl -v http://example.com', $command->build());
     }
 
     public function testBuildWithUrlAndOptions(): void
@@ -56,7 +56,7 @@ class CommandTest extends TestCase
         $command = $this->getNewCommand();
         $command->addOption('-v');
         $command->addOption('-L');
-        $this->assertEquals('curl -v -L http://example.com', $command->build());
+        $this->assertSame('curl -v -L http://example.com', $command->build());
 
 
     }
@@ -66,26 +66,26 @@ class CommandTest extends TestCase
         $command = $this->getNewCommand();
 
         $command->setOptions([]);
-        $this->assertEquals('curl http://example.com', $command->build());
+        $this->assertSame('curl http://example.com', $command->build());
 
         $command->setOptions(['-L' => [null], '-v' => [null]]);
-        $this->assertEquals('curl -L -v http://example.com', $command->build());
+        $this->assertSame('curl -L -v http://example.com', $command->build());
 
         $command->setOptions(['-L' => null, '-v' => null]);
-        $this->assertEquals('curl -L -v http://example.com', $command->build());
+        $this->assertSame('curl -L -v http://example.com', $command->build());
 
         $command->setOptions(['-d' => 'test1', '-H' => 'test2']);
-        $this->assertEquals("curl -d 'test1' -H 'test2' http://example.com", $command->build());
+        $this->assertSame("curl -d 'test1' -H 'test2' http://example.com", $command->build());
 
         $command->setOptions(['-H' => ['test1', 'test2']]);
-        $this->assertEquals("curl -H 'test1' -H 'test2' http://example.com", $command->build());
+        $this->assertSame("curl -H 'test1' -H 'test2' http://example.com", $command->build());
 
         $command->setOptions(['-L', '-v']);
-        $this->assertEquals('curl -L -v http://example.com', $command->build());
+        $this->assertSame('curl -L -v http://example.com', $command->build());
 
         // mixed format
         $command->setOptions(['-L', '-v' => null, '--insecure' => [null], '-d' => 'test1', '-H' => ['test2']]);
-        $this->assertEquals("curl -L -v --insecure -d 'test1' -H 'test2' http://example.com", $command->build());
+        $this->assertSame("curl -L -v --insecure -d 'test1' -H 'test2' http://example.com", $command->build());
     }
 
     public function testBuildDuplicatedOptions(): void
@@ -94,7 +94,7 @@ class CommandTest extends TestCase
         $command->addOption('-v');
         $command->addOption('-L');
         $command->addOption('-L');
-        $this->assertEquals('curl -v -L -L http://example.com', $command->build());
+        $this->assertSame('curl -v -L -L http://example.com', $command->build());
     }
 
     public function testBuildSetTemplate(): void
@@ -103,40 +103,40 @@ class CommandTest extends TestCase
         $command->setTemplate(Command::TEMPLATE_COMMAND_NAME . Command::TEMPLATE_URL . Command::TEMPLATE_OPTIONS);
         $command->addOption('-v');
         $command->addOption('-L');
-        $this->assertEquals('curl http://example.com -v -L', $command->build());
+        $this->assertSame('curl http://example.com -v -L', $command->build());
 
         $command->setTemplate(Command::TEMPLATE_COMMAND_NAME . Command::TEMPLATE_URL);
-        $this->assertEquals('curl http://example.com', $command->build());
+        $this->assertSame('curl http://example.com', $command->build());
 
         $command->setTemplate('');
-        $this->assertEquals('', $command->build());
+        $this->assertSame('', $command->build());
     }
 
     public function testBuildWithLongOptions(): void
     {
         $command = $this->getNewCommand();
         $command->addOption('--verbose');
-        $this->assertEquals('curl --verbose http://example.com', $command->build());
+        $this->assertSame('curl --verbose http://example.com', $command->build());
 
         $command->addOption('--location');
-        $this->assertEquals('curl --verbose --location http://example.com', $command->build());
+        $this->assertSame('curl --verbose --location http://example.com', $command->build());
     }
 
     public function testBuildWithArgumentsToOptions(): void
     {
         $command = $this->getNewCommand();
         $command->addOption('-d', 'arbitrary');
-        $this->assertEquals("curl -d 'arbitrary' http://example.com", $command->build());
+        $this->assertSame("curl -d 'arbitrary' http://example.com", $command->build());
 
         // data from file
         $command = $this->getNewCommand();
         $command->addOption('-d', '@json.txt');
-        $this->assertEquals("curl -d '@json.txt' http://example.com", $command->build());
+        $this->assertSame("curl -d '@json.txt' http://example.com", $command->build());
 
         // argument with spaces
         $command = $this->getNewCommand();
         $command->addOption('-d', 'I am your father');
-        $this->assertEquals("curl -d 'I am your father' http://example.com", $command->build());
+        $this->assertSame("curl -d 'I am your father' http://example.com", $command->build());
     }
 
     public function testBuildSetQuoteCharacter(): void
@@ -145,16 +145,16 @@ class CommandTest extends TestCase
         $command->addOption('-d', 'arbitrary');
 
         // default is singe
-        $this->assertEquals("curl -d 'arbitrary' http://example.com", $command->build());
+        $this->assertSame("curl -d 'arbitrary' http://example.com", $command->build());
 
         $command->setQuoteCharacter(Command::QUOTE_DOUBLE);
-        $this->assertEquals('curl -d "arbitrary" http://example.com', $command->build());
+        $this->assertSame('curl -d "arbitrary" http://example.com', $command->build());
 
         $command->setQuoteCharacter(Command::QUOTE_SINGLE);
-        $this->assertEquals("curl -d 'arbitrary' http://example.com", $command->build());
+        $this->assertSame("curl -d 'arbitrary' http://example.com", $command->build());
 
         $command->setQuoteCharacter(Command::QUOTE_NONE);
-        $this->assertEquals('curl -d arbitrary http://example.com', $command->build());
+        $this->assertSame('curl -d arbitrary http://example.com', $command->build());
     }
 
     public function testBuildEscapeArguments(): void
@@ -168,7 +168,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->setQuoteCharacter(Command::QUOTE_SINGLE);
         $command->addOption('-d', $argument);
-        $this->assertEquals($expected, $command->build());
+        $this->assertSame($expected, $command->build());
 
         $argument = <<<ARG
 x=test"2
@@ -179,7 +179,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->setQuoteCharacter(Command::QUOTE_SINGLE);
         $command->addOption('-d', $argument);
-        $this->assertEquals($expected, $command->build());
+        $this->assertSame($expected, $command->build());
 
         $argument = <<<ARG
 x=test'1"2
@@ -190,7 +190,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->setQuoteCharacter(Command::QUOTE_SINGLE);
         $command->addOption('-d', $argument);
-        $this->assertEquals($expected, $command->build());
+        $this->assertSame($expected, $command->build());
 
         $argument = <<<ARG
 x=test'1
@@ -201,7 +201,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->setQuoteCharacter(Command::QUOTE_DOUBLE);
         $command->addOption('-d', $argument);
-        $this->assertEquals($expected, $command->build());
+        $this->assertSame($expected, $command->build());
 
         $argument = <<<ARG
 x=test"2
@@ -212,7 +212,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->setQuoteCharacter(Command::QUOTE_DOUBLE);
         $command->addOption('-d', $argument);
-        $this->assertEquals($expected, $command->build());
+        $this->assertSame($expected, $command->build());
 
         $argument = <<<ARG
 x=test'1"2
@@ -223,7 +223,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->setQuoteCharacter(Command::QUOTE_DOUBLE);
         $command->addOption('-d', $argument);
-        $this->assertEquals($expected, $command->build());
+        $this->assertSame($expected, $command->build());
     }
 
     public function testBuildMultipleOptions(): void
@@ -231,7 +231,7 @@ EXP;
         $command = $this->getNewCommand();
         $command->addOption('-H', 'Connection: keep-alive');
         $command->addOption('-H', 'Cache-Control: max-age=0');
-        $this->assertEquals("curl -H 'Connection: keep-alive' -H 'Cache-Control: max-age=0' http://example.com", $command->build());
+        $this->assertSame("curl -H 'Connection: keep-alive' -H 'Cache-Control: max-age=0' http://example.com", $command->build());
     }
 
     public function testBuildAddOptions(): void
@@ -242,7 +242,7 @@ EXP;
             '-L',
             '-d' => 'test'
         ]);
-        $this->assertEquals("curl -v -L -d 'test' http://example.com", $command->build());
+        $this->assertSame("curl -v -L -d 'test' http://example.com", $command->build());
     }
 
     public function testBuildPsrHttpRequest(): void
@@ -250,7 +250,7 @@ EXP;
         $request = new Request('GET', 'http://example.com');
         $command = new Command();
         $command->setRequest($request);
-        $this->assertEquals('curl http://example.com', $command->build());
+        $this->assertSame('curl http://example.com', $command->build());
 
         $request = new Request('POST', 'http://example.com', [
             'Connection' => ['keep-alive'],
@@ -262,13 +262,13 @@ EXP;
 
         $command = new Command();
         $command->setRequest($request);
-        $this->assertEquals("curl -H 'Connection: keep-alive' -H 'Accept: text/html, application/xhtml+xml' -d 'data' http://example.com", $command->build());
+        $this->assertSame("curl -H 'Connection: keep-alive' -H 'Accept: text/html, application/xhtml+xml' -d 'data' http://example.com", $command->build());
 
         $command = new Command();
         $command->setRequest($request, false);
-        $this->assertEquals('curl', $command->build());
+        $this->assertSame('curl', $command->build());
         $command->parseRequest();
-        $this->assertEquals("curl -H 'Connection: keep-alive' -H 'Accept: text/html, application/xhtml+xml' -d 'data' http://example.com", $command->build());
+        $this->assertSame("curl -H 'Connection: keep-alive' -H 'Accept: text/html, application/xhtml+xml' -d 'data' http://example.com", $command->build());
     }
 
     public function testBuildPsrHttpRequestHeaderExceptions(): void
@@ -282,7 +282,7 @@ EXP;
 
         $command = new Command();
         $command->setRequest($request);
-        $this->assertEquals("curl -H 'Set-Cookie: test1=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly' -H 'Set-Cookie: test2=2; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly' http://example.com", $command->build());
+        $this->assertSame("curl -H 'Set-Cookie: test1=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly' -H 'Set-Cookie: test2=2; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly' http://example.com", $command->build());
     }
 
     public function testBuildParseRequest(): void


### PR DESCRIPTION
# Changed log

- Replacing the `assertEquals` with `assertSame` to make assert equals strict.