### PR TITLE
Fix duplicate options handling

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -339,15 +339,18 @@ final class Command
         $formattedOptions = [];
         foreach ($options as $option => $arguments) {
             $option = trim((string)$option);
+
             if (strpos($option, '-') !== 0) {
                 // ['-L', '-v']
-                $formattedOptions[$arguments] = [null];
+                $option = (string)$arguments;
+                $arguments = [null];
             } elseif (!is_array($arguments)) {
                 // ['-L' => null, '-v' => null]
-                $formattedOptions[$option] = [$arguments];
-            } else {
-                // internal format
-                $formattedOptions[$option] = $arguments;
+                $arguments = [$arguments];
+            }
+
+            foreach ($arguments as $argument) {
+                $formattedOptions[$option][] = $argument;
             }
         }
 

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -97,6 +97,20 @@ class CommandTest extends TestCase
         $this->assertSame('curl -v -L -L http://example.com', $command->build());
     }
 
+    public function testBuildDuplicatedOptionsAddOptions(): void
+    {
+        $command = $this->getNewCommand();
+        $command->addOptions(['-v', '-v']);
+        $this->assertSame('curl -v -v http://example.com', $command->build());
+    }
+
+    public function testBuildDuplicatedOptionsSetOptions(): void
+    {
+        $command = $this->getNewCommand();
+        $command->setOptions(['-v', '-v']);
+        $this->assertSame('curl -v -v http://example.com', $command->build());
+    }
+
     public function testBuildSetTemplate(): void
     {
         $command = $this->getNewCommand();


### PR DESCRIPTION
## Summary
- handle duplicate options in toInternalFormat
- add regression tests for duplicate options via addOptions and setOptions

## Testing
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_683f72313e108331bf709b4bdfef7ab6