### PR TITLE
Fix default quote comment

### DIFF
--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -144,7 +144,7 @@ class CommandTest extends TestCase
         $command = $this->getNewCommand();
         $command->addOption('-d', 'arbitrary');
 
-        // default is singe
+        // default is single
         $this->assertSame("curl -d 'arbitrary' http://example.com", $command->build());
 
         $command->setQuoteCharacter(Command::QUOTE_DOUBLE);


### PR DESCRIPTION
## Summary
- fix comment message in the quote character test

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f75b6c7448331b5dc58ed3eac5260