### PR TITLE
Fix quote constant names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Quoting character can be changed to double quote or removed
 ```php
 $command->addOption('-d', 'data1');
 $command->addOption('-d', 'data"2');
-$command->setQuoteCharacter(Command::QUOTE_CHARACTER_DOUBLE);
+$command->setQuoteCharacter(Command::QUOTE_DOUBLE);
 // curl -d "data" -d "data\"2"
 
 $command->addOption('-d', 'data');
-$command->setQuoteCharacter(Command::QUOTE_CHARACTER_NONE);
+$command->setQuoteCharacter(Command::QUOTE_NONE);
 // curl -d data
 ``` 


### PR DESCRIPTION
## Summary
- update README to use `QUOTE_DOUBLE` and `QUOTE_NONE`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_683f760a3e948331bee000a2aa6adf8a