### PR TITLE
Add numeric argument support for options

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -231,7 +231,7 @@ final class Command
                 foreach ($arguments as $argument) {
                     $optionsString .= ' ' . $option;
                     if ($argument !== null) {
-                        $optionsString .= ' ' . $this->quote($argument);
+                        $optionsString .= ' ' . $this->quote((string)$argument);
                     }
                 }
             }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -157,6 +157,14 @@ class CommandTest extends TestCase
         $this->assertSame('curl -d arbitrary http://example.com', $command->build());
     }
 
+    public function testAddOptionWithNumericArgument(): void
+    {
+        $command = $this->getNewCommand();
+        $command->setQuoteCharacter(Command::QUOTE_NONE);
+        $command->addOption('-d', 123);
+        $this->assertSame('curl -d 123 http://example.com', $command->build());
+    }
+
     public function testBuildEscapeArguments(): void
     {
         $argument = <<<ARG


### PR DESCRIPTION
## Summary
- allow non-string arguments for command options
- test numeric option argument handling
- use helper method for new numeric option test

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_683f761ccdf48331b3da94d6ebfffdba