### PR TITLE
Add PHP 8.4 to CI matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- add PHP 8.4 to GitHub Actions matrix

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_683f83c75c9883319e18a457f31ce731